### PR TITLE
fix r cmd check notes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,8 +2,10 @@
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^README\.Rmd$
+^README\.html$
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
 ^\.github$
 ^\.httr-oauth$
+^\.devcontainer$

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,60 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/r
+{
+	"name": "R (rocker/r-ver base)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "ghcr.io/rocker-org/devcontainer/r-ver:4.3", //commma needed if other sections are used.
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		// if we want to install r packages using pak
+		// more info: https://github.com/rocker-org/devcontainer-features/blob/main/src/r-packages/README.md
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+			"packages": "clang,clang-format,clang-tidy,cmake,doxygen,g++,gcc,libxt6,libxtst6,make,ninja-build"			
+		},
+		 "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
+			"packages": "blastula,dplyr,devtools,ggplot2,jsonlite,kableExtra,methods,mockery,parsedate,Rcpp,RcppEigen,scales,snowfall,TMB,tibble,tidyr,usethis",
+			"installSystemRequirements": true
+		  },
+		 // option to run rstudio. you can type rserver into the command line to
+		 // get an session going (opens on a port, that you can open as a 
+		 // separate browser window).
+		 // more details: https://github.com/rocker-org/devcontainer-features/blob/main/src/rstudio-server/README.md
+		 "ghcr.io/rocker-org/devcontainer-features/rstudio-server:0": {}
+		},
+	// // if we want quarto cli
+	     // more info: https://github.com/rocker-org/devcontainer-features/blob/main/src/quarto-cli/README.md
+	//    "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {}
+	// },
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "echo 'options(repos = c(CRAN = \"https://cloud.r-project.org\"))' | sudo sh -c 'cat - >>\"${R_HOME}/etc/Rprofile.site\"'",
+	
+	// Configure tool-specific properties.
+	 "customizations": {
+	   "vscode": {
+	 		// Set *default* container specific settings.json values on container create.
+	 		// Add the IDs of extensions you want installed when the container is created.
+	 		"extensions": [
+		        // if we want liveshare.
+	 			"ms-vsliveshare.vsliveshare",
+				"ms-vscode.cpptools",
+				 "ms-vscode.cmake-tools",
+				 "GitHub.codespaces",
+				 "bbenoist.Doxygen",
+				 "matepek.vscode-catch2-text-adapter",
+				 "hbenl.vscode-test-explorer",
+				 "reditorsupport.r",
+				 "rdebugger.r-debugger",
+                                 "github.vscode-pull-request-github"
+	 		]
+	     }
+	 
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}
+}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,6 @@ Imports:
     blastula,
     dplyr,
     gh,
-    httr,
     jsonlite,
     kableExtra,
     knitr,
@@ -20,7 +19,8 @@ Imports:
     tidyr
 Suggests:
     ggplot2,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    httr
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/calculate_.R
+++ b/R/calculate_.R
@@ -1,3 +1,9 @@
+# To remove the WARNING
+# no visible binding for global variable
+utils::globalVariables(c(
+  "org", "repo", "day", "stars"
+))
+
 #' Calculate the cumulative number of stars
 #'
 #' For each combination of organization and repository, calculate the

--- a/R/create_issue_table.R
+++ b/R/create_issue_table.R
@@ -1,3 +1,9 @@
+# To remove the WARNING
+# no visible binding for global variable
+utils::globalVariables(c(
+  "label_col"
+))
+
 #' Creates a table of issues
 #'
 #' This function takes a \code{json} input table generated from the Github

--- a/R/get_.R
+++ b/R/get_.R
@@ -1,3 +1,9 @@
+# To remove the WARNING
+# no visible binding for global variable
+utils::globalVariables(c(
+  "owner", "starred_at"
+))
+
 #' Query the Github API for a list of issues associated with a repository
 #'
 #' The issues for a given repository and all of their metadata are returned as


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* address issue #10 to fix notes from R CMD Check

# How have you implemented the solution?
* use utils::globalVariables() to remove the warning about no visible binding for a global variable
* update(DESCRIPTION): move httr from Imports to Suggests since it is used in .Rhistory
* add devcontainer.json with required R packages
* update(.Rbuidignore): add README.html and .devcontainer/
Note:
- Issue #10 reported 1 warning and 3 notes from R CMD Check, but the warning could not be reproduced locally. This update focuses on resolving the notes.
- Remaining note: `Unexported object imported by a ':::' call: ‘gh:::gh_has_next’. See the note in ?`:::` about the use of this operator.`
    - There are multiple solutions from [stackoverflow](https://stackoverflow.com/questions/63023526/unexported-object-imported-by-a-call-tsfeaturesscalets): 1) Contact the package author and ask them to export the function. 2) Copy the function source code and cite the author appropriately. 3) Use getFromNamespace() `fun <- utils::getFromNamespace("fun", "pkg")`.
    - I'm not sure which approach is best in our case.

# Does the PR impact any other area of the project, maybe another repo?
* No

